### PR TITLE
Ensure trace output includes module offsets

### DIFF
--- a/src/symbolResolver.cpp
+++ b/src/symbolResolver.cpp
@@ -332,7 +332,11 @@ ResolvedSymbol SymbolResolver::resolveAddress(uint64_t address) {
     
     // 在模块中解析符号
     ResolvedSymbol result = resolveInModule(address, moduleInfo);
-    
+
+    // 无论是否找到具体符号，都补充模块信息，方便后续使用
+    result.moduleBase = moduleInfo->baseAddress;
+    result.modulePath = moduleInfo->path;
+
     // 缓存结果（无论是否成功）
     symbolCache_[address] = result;
     

--- a/src/textRecorder.cpp
+++ b/src/textRecorder.cpp
@@ -73,7 +73,7 @@ void TextRecorder::record(const TraceRecord &record) {
         auto addrSymbol = getAddressSymbol(record);
         bool printedModuleOffset = false;
         auto resolvedModule = GlobalSymbolResolver::getInstance().resolveAddress(record.address);
-        if (resolvedModule.isValid && resolvedModule.moduleBase != 0) {
+        if (resolvedModule.moduleBase != 0) {
             std::string moduleName = resolvedModule.modulePath;
             auto pos = moduleName.find_last_of("/\\");
             if (pos != std::string::npos && pos + 1 < moduleName.size()) {


### PR DESCRIPTION
## Summary
- ensure resolved symbols carry module path/base information even when no concrete symbol is found
- update text recorder to always emit module+offset suffix when module information is known

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cbdc11bc60832288f55ed3a6c882da